### PR TITLE
Fix Semver for rc versions

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,0 +1,4 @@
+{
+    "DisableAll": true,
+    "Enable": ["deadcode","dupl","errcheck","goconst","gocyclo","goconst","goimports","golint","gosimple","vet", "vetshadow"]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 ### Changed
+## [0.3.1]
+### Added
+### Changed
+### Fixed
+All release candidates now use the -rc denotion in their semver
 ## [0.3.0] 2018-12-21
 ### Added
 Export a version which can be used in go module setups. (includes the no standard v prefix)

--- a/semver/projectversionservice.go
+++ b/semver/projectversionservice.go
@@ -71,9 +71,9 @@ func (p *ProjectVersionService) Bump(component svermaker.SemverComponent, prerel
 		case svermaker.PATCH:
 			prerelease, _ = m.MakePrerelease("rc")
 		case svermaker.MINOR:
-			prerelease, _ = m.MakePrerelease("beta")
+			prerelease, _ = m.MakePrerelease("rc")
 		case svermaker.MAJOR:
-			prerelease, _ = m.MakePrerelease("alpha")
+			prerelease, _ = m.MakePrerelease("rc")
 		}
 	}
 	v.Current.Pre = prerelease

--- a/version.yml
+++ b/version.yml
@@ -1,2 +1,2 @@
-current: 0.3.0
-next: 0.3.0
+current: 0.3.1
+next: 0.3.1


### PR DESCRIPTION
They are now all using -rc instead of -rc, -beta -alpha